### PR TITLE
Support dependencies from custom loaders

### DIFF
--- a/spec/dependencies.coffee
+++ b/spec/dependencies.coffee
@@ -185,3 +185,14 @@ describe 'Finding component dependencies', ->
           names = dep.components.map (d) -> d.name
           chai.expect(names).to.eql ['Bar', 'Foo', 'Baz']
           done()
+    describe 'with a graph that depends on components from a dynamic component loader', ->
+      it 'should find the dependencies and register the loader', (done) ->
+        manifest.dependencies.find modules, 'deps/WithLoader',
+          baseDir: baseDir
+        , (err, dependedModules) ->
+          return done err if err
+          chai.expect(dependedModules.length).to.equal 3
+          [withLoader] = dependedModules.filter (m) -> m.name is 'loader'
+          chai.expect(withLoader.noflo.loader).to.equal 'lib/ComponentLoader'
+          chai.expect(withLoader.components).to.eql []
+          done()

--- a/spec/fixtures/noflo-deps/graphs/WithLoader.fbp
+++ b/spec/fixtures/noflo-deps/graphs/WithLoader.fbp
@@ -1,0 +1,6 @@
+# @runtime noflo-nodejs
+
+INPORT=Foo.IN:IN
+OUTPORT=Bar.OUT:OUT
+
+Foo(dep/Baz) OUT -> IN Foo2(loader/LoadedAtRuntime) OUT -> IN Bar(deps/Bar)

--- a/spec/fixtures/noflo-deps/node_modules/noflo-loader/lib/ComponentLoader.coffee
+++ b/spec/fixtures/noflo-deps/node_modules/noflo-loader/lib/ComponentLoader.coffee
@@ -1,0 +1,2 @@
+module.exports = (loader, callback) ->
+  callback null

--- a/spec/fixtures/noflo-deps/node_modules/noflo-loader/package.json
+++ b/spec/fixtures/noflo-deps/node_modules/noflo-loader/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "noflo-loader",
+  "noflo": {
+    "loader": "lib/ComponentLoader"
+  }
+}


### PR DESCRIPTION
This makes the dependency finder aware of custom NoFlo componentloaders. Caveat is that we don't know for sure the custom loader provides a given component, so we assume it will be available if we just register the loader.

Fixes #5 