### PR TITLE
Fix mixed use of namespaces

### DIFF
--- a/spec/fixtures/noflo-deps/graphs/Hello.fbp
+++ b/spec/fixtures/noflo-deps/graphs/Hello.fbp
@@ -1,6 +1,6 @@
 # @runtime noflo-nodejs
 
 INPORT=Foo.IN:IN
-OUTPORT=Bar.OUT:OUT
+OUTPORT=Bar2.OUT:OUT
 
-Foo(dep/Baz) OUT -> IN Foo2(dep/Foo) OUT -> IN Bar(deps/Bar)
+Foo(dep/Baz) OUT -> IN Foo2(dep/Foo) OUT -> IN Bar(deps/Bar) OUT -> IN Bar2(Bar)


### PR DESCRIPTION
With the previous release, dependency finding could fail in a graph that used components with mixed namespacing (`core/Repeat` and `Repeat`). This adds a test for the case and fixes it